### PR TITLE
Clean the xml more

### DIFF
--- a/source/funkin/editors/character/CharacterEditor.hx
+++ b/source/funkin/editors/character/CharacterEditor.hx
@@ -361,8 +361,19 @@ class CharacterEditor extends UIState {
 		if (charXML.exists("flipX") && !character.flipX) charXML.remove("flipX");
 		if (charXML.exists("scale") && character.scale.x == 1) charXML.remove("scale");
 		if (charXML.exists("antialiasing") && character.antialiasing) charXML.remove("antialiasing");
+		if (charXML.exists("sprite") && character.sprite == character.curCharacter) charXML.remove("sprite");
+		if (charXML.exists("icon") && character.icon == character.curCharacter) charXML.remove("icon");
 
-		return "<!DOCTYPE codename-engine-character>\n" + Printer.print(charXML, true);
+		for (a in charXML.elements())
+			if (a.nodeName == "anim") {
+				if (a.exists("x") && a.get("x") == "0") a.remove("x");
+				if (a.exists("y") && a.get("y") == "0") a.remove("y");
+				if (a.exists("fps") && a.get("fps") == "24") a.remove("fps");
+				if (a.exists("loop") && a.get("loop") == "false") a.remove("loop");
+			}
+
+		var xmlThingYea:String = "<!DOCTYPE codename-engine-character>\n" + Printer.print(charXML, Options.editorPrettyPrint);
+		return Options.editorPrettyPrint ? xmlThingYea : xmlThingYea.replace("\n", "");
 	}
 
 	function _edit_undo(_) {


### PR DESCRIPTION
I already do this with my xmls manually, but having it be automatic would be nice too.

An xml called "rodriguez-phase2" that looks like this:
```xml
<!DOCTYPE codename-engine-character>
<character sprite="rodriguez-phase2" icon="rodriguez-phase2">
	<anim name="idle" anim="idle" x="0" y="0" fps="24" loop="false"/>
	<anim name="singUP" anim="up" x="0" y="0" fps="24" loop="false"/>
	<anim name="singLEFT" anim="left" x="0" y="0" fps="24" loop="false"/>
	<anim name="singRIGHT" anim="right" x="0" y="0" fps="24" loop="false"/>
	<anim name="singDOWN" anim="down" x="0" y="0" fps="24" loop="false"/>
</character>
```

Would now look like this when saving (If pretty print is disabled):
```xml
<!DOCTYPE codename-engine-character>
<character>
	<anim name="idle" anim="idle"/>
	<anim name="singUP" anim="up"/>
	<anim name="singLEFT" anim="left"/>
	<anim name="singRIGHT" anim="right"/>
	<anim name="singDOWN" anim="down"/>
</character>
```