### PR TITLE
Roses cutscene fix

### DIFF
--- a/assets/songs/roses/dialogue.hx
+++ b/assets/songs/roses/dialogue.hx
@@ -1,4 +1,5 @@
-function next(first:Bool) {
+function next(event:DialogueNextLineEvent) {
+	var first = event.playFirst;
 	if(first && canProceed) {
 		canProceed = false;
 		dialogueLines[0].playSound.play();


### PR DESCRIPTION
This solves a bug that makes "Roses" cutscene not work properly. The function call `next` now has an event-type parameter instead of a boolean.

Forgot to change this when I made [this PR](https://github.com/CodenameCrew/CodenameEngine/pull/443).