### PR TITLE
"BetaWarningState" import redirect + small fix

### DIFF
--- a/source/funkin/backend/scripting/Script.hx
+++ b/source/funkin/backend/scripting/Script.hx
@@ -112,9 +112,9 @@ class Script extends FlxBasic implements IFlxDestroyable {
 	 * if you wanna modify it, please edit `hscript.Interp.importRedirects` directly.
 	**/
 	public static function getDefaultImportRedirects():Map<String, String> {
-		var redirects:Map<String, String> = [
-		];
+		var redirects:Map<String, String> = [];
 
+		// Events
 		final events = "funkin.backend.scripting.events.";
 		redirects[events + "CharacterNodeEvent"]			= events + "character.CharacterNodeEvent";
 		redirects[events + "CharacterXMLEvent"]				= events + "character.CharacterXMLEvent";
@@ -145,6 +145,9 @@ class Script extends FlxBasic implements IFlxDestroyable {
 		redirects[events + "PlayAnimEvent"]					= events + "sprite.PlayAnimEvent";
 		redirects[events + "StageNodeEvent"]				= events + "stage.StageNodeEvent";
 		redirects[events + "StageXMLEvent"]					= events + "stage.StageXMLEvent";
+
+		// Old State Names
+		redirects["funkin.menus.BetaWarningState"] 			= "funkin.menus.WarningState";
 
 		return redirects;
 	}

--- a/source/funkin/backend/system/Main.hx
+++ b/source/funkin/backend/system/Main.hx
@@ -11,6 +11,7 @@ import flixel.math.FlxRect;
 import flixel.system.ui.FlxSoundTray;
 import funkin.backend.assets.AssetsLibraryList;
 import funkin.backend.assets.ModsFolder;
+import funkin.backend.assets.AssetSource;
 import funkin.backend.system.framerate.SystemInfo;
 import funkin.backend.system.modules.*;
 import funkin.editors.SaveWarning;


### PR DESCRIPTION
This basically redirects the `BetaWarningState` import to `WarningState` for backwards compatibility.

Also, I get this error on `Main.hx:148` that doesn't affect compilation for some reason:
<img width="1275" height="297" alt="image" src="https://github.com/user-attachments/assets/844140ac-9eeb-4ca4-9efa-e6463a1c055f" />
So, I imported the enum abstract `funkin.backend.assets.AssetSource` in `Main.hx` to solve the issue.